### PR TITLE
repl.py: handle OSError on os.get_terminal_size()

### DIFF
--- a/loopgpt/loops/repl.py
+++ b/loopgpt/loops/repl.py
@@ -74,9 +74,12 @@ def prompt(speaker, line):
     return input()
 
 
-def write_divider(big=False):
+def write_divider(big=False, default_columns=80):
     char = "\u2501" if big else "\u2500"
-    columns = os.get_terminal_size().columns
+    try:
+        columns = os.get_terminal_size().columns
+    except OSError:
+        columns = default_columns
     print(char * columns)
 
 


### PR DESCRIPTION
Handles OSError on os.get_terminal_size which seems not to be compatible with some simulated environments such as Jupyterlab (tested on it).
