### PR TITLE
Modified ListFiles class to clearly distinguish files from directories

### DIFF
--- a/loopgpt/tools/filesystem.py
+++ b/loopgpt/tools/filesystem.py
@@ -120,7 +120,7 @@ class ListFiles(BaseTool):
                         if not exclude_dirs:
                             entries_list.append(f"{entry.name}/")
                         if recursive:
-                            entries_list.extend(self.run(os.path.join(path, entry.name), recursive)["result"])
+                            entries_list.extend(self.run(os.path.join(path, entry.name), recursive, show_hidden, exclude_dirs)["result"])
                     else:
                         entries_list.append(entry.name)
         return {"result": entries_list}

--- a/loopgpt/tools/filesystem.py
+++ b/loopgpt/tools/filesystem.py
@@ -99,11 +99,23 @@ class ListFiles(BaseTool):
     @property
     def resp(self):
         return {
-            "files": "list of files",
+            "files": "list of files and directories",
         }
+    
+    @property
+    def desc(self):
+        return "List files and directories in a given path. Directories end with a trailing slash."
 
     def run(self, *_, **__):
-        return os.listdir()
+        entries_list = []
+        with os.scandir('.') as entries:
+            for entry in entries:
+                if entry.is_dir():
+                    entry_str = f"{entry.name}/"
+                else:
+                    entry_str = entry.name
+                entries_list.append(entry_str)
+            return entries_list
 
 
 FileSystemTools = [


### PR DESCRIPTION
`list_files` command should now list files and directories in a clearer manner i.e. directories will have a trailing slash:

```
# Expected agent output:
SYSTEM: Executing command: list_files
SYSTEM: list_files output: ['.env', '.env.template', '.git/', '.github/', '.gitignore', 'docs/', 'examples/', 'LICENSE', 'load.py', 'loopgpt/', 'README.md', 'requirements.txt', 'setup.py', 'tests/',  '__pycache__/'] 
```