### PR TITLE
Fix webdriver.Chrome: executable_path has been deprecated

### DIFF
--- a/loopgpt/tools/browser.py
+++ b/loopgpt/tools/browser.py
@@ -4,6 +4,7 @@ Adapted from Auto-GPT (https://github.com/Significant-Gravitas/Auto-GPT)
 
 from webdriver_manager.chrome import ChromeDriverManager
 from selenium import webdriver
+from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from bs4 import BeautifulSoup
@@ -60,7 +61,8 @@ class Browser(BaseTool):
     def _init_chrome_driver(self):
         try:
             self.driver = webdriver.Chrome(
-                executable_path=ChromeDriverManager().install(), options=self.options
+                service=Service(ChromeDriverManager().install()),
+                options=self.options
             )
         except:
             logger.log(


### PR DESCRIPTION
`executable_path` has been deprecated in Selenium 4 and is no longer usable: https://github.com/SeleniumHQ/selenium/issues/9125. This makes _init_chrome_driver fail every time with the following message for me: `WebDriver.__init__() got an unexpected keyword argument 'executable_path'`. (note that without removing the error handling you would not see this message because it falls back to Firefox)

This PR changes to `executable_path` argument to equivalent `service` argument.