### PR TITLE
update: fix config issues when passing azure endpoint url

### DIFF
--- a/openvibe/config.py
+++ b/openvibe/config.py
@@ -197,14 +197,30 @@ def _deep_merge(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]
 # Loading
 # ---------------------------------------------------------------------------
 
+_JSONC_COMMENT_RE = re.compile(
+    r'"(?:[^"\\]|\\.)*"' r"|" r"//[^\n]*" r"|" r"/\*.*?\*/",
+    re.DOTALL,
+)
+
+
+def _strip_jsonc_comments(text: str) -> str:
+    def _replace(match: re.Match) -> str:
+        s = match.group(0)
+        if s.startswith('"'):
+            return s
+        return "\n" * s.count("\n")
+
+    return _JSONC_COMMENT_RE.sub(_replace, text)
+
 
 def _load_json(path: Path) -> dict[str, Any]:
     """Load a JSON (or JSONC — JSON with // comments) file."""
-    text = path.read_text(encoding="utf-8")
-    # Strip single-line // comments (simple approach, not spec-complete)
-    lines = [re.sub(r"\s*//.*$", "", line) for line in text.splitlines()]
     try:
-        return json.loads("\n".join(lines))
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    try:
+        return json.loads(_strip_jsonc_comments(text))
     except json.JSONDecodeError as exc:
         raise ValueError(f"Invalid JSON in {path}: {exc}") from exc
 

--- a/openvibe/tui/app.py
+++ b/openvibe/tui/app.py
@@ -16,6 +16,11 @@ from textual.binding import Binding
 from textual.widgets import Footer
 
 from openvibe.api import OpenVibe
+import os
+
+from openvibe.config import load_config
+from openvibe.provider.provider import get_provider
+
 
 _CSS = """
 Screen {
@@ -111,12 +116,30 @@ class OpenvibeApp(App[None]):
 
 def _needs_setup(project_dir: Path) -> bool:
     """Return True if no model is configured from any config source."""
-    from openvibe.config import load_config
-
     try:
-        return load_config(project_dir).model is None
+        config = load_config(project_dir)
     except Exception:
         return True
+
+    if config.model is None:
+        return True
+
+    provider_id = config.model.provider_id
+    provider_info = get_provider(provider_id)
+    if provider_info is None:
+        return False
+
+    pcfg = config.provider.get(provider_id)
+    if pcfg and pcfg.api_key:
+        return False
+
+    if provider_info.env_key and os.environ.get(provider_info.env_key):
+        return False
+
+    if provider_id == "azure" and os.environ.get("AZURE_OPENAI_API_KEY"):
+        return False
+
+    return True
 
 
 def run_tui(project_dir: Path | None = None) -> None:


### PR DESCRIPTION
Issue:

```
 ╭───────────────────── Traceback (most recent call last) ──────────────────────╮
│ /Users/abhijithneilabraham/Documents/GitHub/loopgpt/openvibe/config.py:207   │
│ in _load_json                                                                │
│                                                                              │
│   204 │   # Strip single-line // comments (simple approach, not spec-complet │
│   205 │   lines = [re.sub(r"\s*//.*$", "", line) for line in text.splitlines │
│   206 │   try:                                                               │
│ ❱ 207 │   │   return json.loads("\n".join(lines))                            │
│   208 │   except json.JSONDecodeError as exc:                                │
│   209 │   │   raise ValueError(f"Invalid JSON in {path}: {exc}") from exc    │
│   210           

                
ValueError: Invalid JSON in 
/Users/abhijithneilabraham/.config/openvibe/openvibe.json: Invalid control 
character at: line 9 column 26 (char 239)
```

Passing model endpoint url to config via initial setup caused issues, this PR fixes parsing http urls with `//` in endpoint while initializing models via setup. 