### PR TITLE
skills for openvibe

### DIFF
--- a/openvibe/api.py
+++ b/openvibe/api.py
@@ -212,8 +212,8 @@ class Session:
     # ------------------------------------------------------------------
 
     def _try_command(self, text: str) -> Response | None:
-        """If *text* is a slash command, execute it and return a Response."""
-        from openvibe.commands import CommandContext, get_command, execute, is_command
+        """If *text* is a registered slash command, execute it and return a Response."""
+        from openvibe.commands import CommandContext, get_command, execute, has_command, is_command
 
         if not is_command(text):
             return None
@@ -221,6 +221,8 @@ class Session:
         if parsed is None:
             return None
         name, args = parsed
+        if not has_command(name):
+            return None  # Not a registered command — let _try_skill handle it.
         ctx = CommandContext(session=self, args=args)
         result = execute(name, ctx)
         return Response(
@@ -228,6 +230,27 @@ class Session:
             text=result.output,
             command_result=result,
         )
+
+    def _try_skill(self, text: str) -> str | None:
+        """If *text* is a skill invocation, return the expanded prompt.
+
+        Skills look like slash commands (``/simplify``, ``/gc``, etc.) but
+        instead of executing locally they expand into a prompt that is sent
+        to the LLM.  Command detection runs first, so registered commands
+        always win over same-named skills.
+        """
+        from openvibe.commands import is_command
+        from openvibe.skill.base import get_registry
+
+        if not is_command(text):
+            return None
+        parts = text[1:].split(None, 1)
+        name = parts[0].lower()
+        args = parts[1] if len(parts) > 1 else ""
+        skill = get_registry().get(name)
+        if skill is None:
+            return None
+        return skill.get_prompt(args)
 
     def send(
         self,
@@ -253,6 +276,11 @@ class Session:
         cmd_response = self._try_command(text)
         if cmd_response is not None:
             return cmd_response
+
+        # Skills expand to a prompt and are forwarded to the LLM.
+        expanded = self._try_skill(text)
+        if expanded is not None:
+            text = expanded
 
         with self._lock:
             if self._state != SessionState.IDLE:
@@ -312,6 +340,11 @@ class Session:
             if callback:
                 callback(cmd_response)
             return
+
+        # Skills expand to a prompt and are forwarded to the LLM.
+        expanded = self._try_skill(text)
+        if expanded is not None:
+            text = expanded
 
         with self._lock:
             if self._state != SessionState.IDLE:
@@ -551,6 +584,7 @@ class OpenVibe:
         from openvibe.config import load_config
         from openvibe.db import create_database
         from openvibe.project import project as _project_module
+        from openvibe.skill.bundled import init_bundled_skills
         from openvibe.tool.base import create_default_registry
 
         if self._config is None:
@@ -564,6 +598,7 @@ class OpenVibe:
         if self._config.mcp:
             self._init_mcp()
 
+        init_bundled_skills()
         return self
 
     def close(self) -> None:
@@ -617,6 +652,9 @@ class OpenVibe:
             self._db, llm, self._bus, self._registry, self._permissions
         )
         self._llm = llm
+
+        from openvibe.skill.bundled import init_bundled_skills
+        init_bundled_skills()
         return self
 
     async def close_async(self) -> None:

--- a/openvibe/api.py
+++ b/openvibe/api.py
@@ -267,7 +267,13 @@ class Session:
 
     def _try_command(self, text: str) -> Response | None:
         """If *text* is a registered slash command, execute it and return a Response."""
-        from openvibe.commands import CommandContext, get_command, execute, has_command, is_command
+        from openvibe.commands import (
+            CommandContext,
+            get_command,
+            execute,
+            has_command,
+            is_command,
+        )
 
         if not is_command(text):
             return None
@@ -708,6 +714,7 @@ class OpenVibe:
         self._llm = llm
 
         from openvibe.skill.bundled import init_bundled_skills
+
         init_bundled_skills()
         return self
 
@@ -929,10 +936,14 @@ async def _run_turn_async(
     from openvibe.config import MessageRole, PermissionAction
     from openvibe.permission.permission import PermissionRequestedEvent
     from openvibe.session import session as _store
-    from openvibe.session.models import (MessageCreatedEvent,
-                                         ReasoningDeltaEvent, TextDeltaEvent,
-                                         TextPart, ToolStateChangedEvent,
-                                         TurnCompletedEvent)
+    from openvibe.session.models import (
+        MessageCreatedEvent,
+        ReasoningDeltaEvent,
+        TextDeltaEvent,
+        TextPart,
+        ToolStateChangedEvent,
+        TurnCompletedEvent,
+    )
 
     accumulated_text = ""
 
@@ -1150,10 +1161,13 @@ async def _run_interrupted_async(
     from openvibe.config import MessageRole, PermissionAction
     from openvibe.permission.permission import PermissionRequestedEvent
     from openvibe.session import session as _store
-    from openvibe.session.models import (MessageCreatedEvent,
-                                         ReasoningDeltaEvent, TextDeltaEvent,
-                                         ToolStateChangedEvent,
-                                         TurnCompletedEvent)
+    from openvibe.session.models import (
+        MessageCreatedEvent,
+        ReasoningDeltaEvent,
+        TextDeltaEvent,
+        ToolStateChangedEvent,
+        TurnCompletedEvent,
+    )
 
     accumulated_text = ""
     abort_async = _asyncio.Event()

--- a/openvibe/commands.py
+++ b/openvibe/commands.py
@@ -171,19 +171,28 @@ def cmd_help(ctx: CommandContext) -> CommandResult:
             f"  [bold cyan]/{name}[/bold cyan]  [dim]{entry.description}[/dim]"
         )
         for sub_name, (_, sub_desc) in sorted(entry.subcommands.items()):
-            lines.append(f"    [bold cyan]/{name} {sub_name}[/bold cyan]  [dim]{sub_desc}[/dim]")
+            lines.append(
+                f"    [bold cyan]/{name} {sub_name}[/bold cyan]  [dim]{sub_desc}[/dim]"
+            )
 
     # Show user-invocable skills section.
     try:
         from rich.markup import escape
 
         from openvibe.skill.base import get_registry
+
         skills = get_registry().user_invocable()
         if skills:
-            lines.append("\n[bold]Available skills[/bold] [dim](expanded by LLM):[/dim]\n")
+            lines.append(
+                "\n[bold]Available skills[/bold] [dim](expanded by LLM):[/dim]\n"
+            )
             for skill in sorted(skills, key=lambda s: s.name):
                 hint = f" {escape(skill.argument_hint)}" if skill.argument_hint else ""
-                aliases = f"  [dim]aliases: {escape(', '.join('/' + a for a in skill.aliases))}[/dim]" if skill.aliases else ""
+                aliases = (
+                    f"  [dim]aliases: {escape(', '.join('/' + a for a in skill.aliases))}[/dim]"
+                    if skill.aliases
+                    else ""
+                )
                 lines.append(
                     f"  [bold cyan]/{escape(skill.name)}{hint}[/bold cyan]  [dim]{escape(skill.description)}[/dim]{aliases}"
                 )
@@ -197,6 +206,7 @@ def cmd_help(ctx: CommandContext) -> CommandResult:
 def cmd_skills(ctx: CommandContext) -> CommandResult:
     try:
         from openvibe.skill.base import get_registry
+
         skills = get_registry().user_invocable()
     except Exception as exc:
         return CommandResult(output=f"[red]Could not load skills:[/red] {exc}")
@@ -206,13 +216,17 @@ def cmd_skills(ctx: CommandContext) -> CommandResult:
 
     from rich.markup import escape
 
-    lines = ["[bold]Available skills[/bold] [dim](each expands into an LLM prompt):[/dim]\n"]
+    lines = [
+        "[bold]Available skills[/bold] [dim](each expands into an LLM prompt):[/dim]\n"
+    ]
     for skill in sorted(skills, key=lambda s: s.name):
         hint = f" {escape(skill.argument_hint)}" if skill.argument_hint else ""
         lines.append(f"  [bold cyan]/{escape(skill.name)}{hint}[/bold cyan]")
         lines.append(f"    [dim]{escape(skill.description)}[/dim]")
         if skill.when_to_use:
-            lines.append(f"    [dim italic]When: {escape(skill.when_to_use)}[/dim italic]")
+            lines.append(
+                f"    [dim italic]When: {escape(skill.when_to_use)}[/dim italic]"
+            )
         if skill.aliases:
             aliases_str = escape(", ".join(f"/{a}" for a in skill.aliases))
             lines.append(f"    [dim]Aliases: {aliases_str}[/dim]")
@@ -386,8 +400,7 @@ def cmd_model(ctx: CommandContext) -> CommandResult:
         provider_id = config.model.provider_id if config.model else "anthropic"
         model_id = args
 
-    from openvibe.config import (ModelRef, save_model_to_global,
-                                 save_model_to_project)
+    from openvibe.config import ModelRef, save_model_to_global, save_model_to_project
 
     new_model = ModelRef(provider_id=provider_id, model_id=model_id)
     model_dict = {"model": {"provider_id": provider_id, "model_id": model_id}}

--- a/openvibe/commands.py
+++ b/openvibe/commands.py
@@ -98,6 +98,11 @@ def get_command(text: str) -> tuple[str, str] | None:
     return name, args
 
 
+def has_command(name: str) -> bool:
+    """Return True if *name* is a registered slash command."""
+    return name in _COMMANDS
+
+
 def _fmt_subcommands(entry: _CommandEntry, name: str) -> str:
     """Format subcommand list for display."""
     lines = []
@@ -151,7 +156,7 @@ def _config(ctx: CommandContext):
 # ---------------------------------------------------------------------------
 
 
-@command("help", "Show available commands")
+@command("help", "Show available commands and skills")
 def cmd_help(ctx: CommandContext) -> CommandResult:
     lines = ["[bold]Available commands:[/bold]\n"]
     for name in sorted(_COMMANDS):
@@ -159,6 +164,52 @@ def cmd_help(ctx: CommandContext) -> CommandResult:
         lines.append(f"  [bold cyan]/{name}[/bold cyan]  [dim]{entry.description}[/dim]")
         for sub_name, (_, sub_desc) in sorted(entry.subcommands.items()):
             lines.append(f"    [bold cyan]/{name} {sub_name}[/bold cyan]  [dim]{sub_desc}[/dim]")
+
+    # Show user-invocable skills section.
+    try:
+        from rich.markup import escape
+
+        from openvibe.skill.base import get_registry
+        skills = get_registry().user_invocable()
+        if skills:
+            lines.append("\n[bold]Available skills[/bold] [dim](expanded by LLM):[/dim]\n")
+            for skill in sorted(skills, key=lambda s: s.name):
+                hint = f" {escape(skill.argument_hint)}" if skill.argument_hint else ""
+                aliases = f"  [dim]aliases: {escape(', '.join('/' + a for a in skill.aliases))}[/dim]" if skill.aliases else ""
+                lines.append(
+                    f"  [bold cyan]/{escape(skill.name)}{hint}[/bold cyan]  [dim]{escape(skill.description)}[/dim]{aliases}"
+                )
+    except Exception:
+        pass
+
+    return CommandResult(output="\n".join(lines))
+
+
+@command("skills", "List available skills (LLM-driven slash commands)")
+def cmd_skills(ctx: CommandContext) -> CommandResult:
+    try:
+        from openvibe.skill.base import get_registry
+        skills = get_registry().user_invocable()
+    except Exception as exc:
+        return CommandResult(output=f"[red]Could not load skills:[/red] {exc}")
+
+    if not skills:
+        return CommandResult(output="[dim]No skills registered.[/dim]")
+
+    from rich.markup import escape
+
+    lines = ["[bold]Available skills[/bold] [dim](each expands into an LLM prompt):[/dim]\n"]
+    for skill in sorted(skills, key=lambda s: s.name):
+        hint = f" {escape(skill.argument_hint)}" if skill.argument_hint else ""
+        lines.append(f"  [bold cyan]/{escape(skill.name)}{hint}[/bold cyan]")
+        lines.append(f"    [dim]{escape(skill.description)}[/dim]")
+        if skill.when_to_use:
+            lines.append(f"    [dim italic]When: {escape(skill.when_to_use)}[/dim italic]")
+        if skill.aliases:
+            aliases_str = escape(", ".join(f"/{a}" for a in skill.aliases))
+            lines.append(f"    [dim]Aliases: {aliases_str}[/dim]")
+        lines.append("")
+
     return CommandResult(output="\n".join(lines))
 
 

--- a/openvibe/skill/__init__.py
+++ b/openvibe/skill/__init__.py
@@ -1,0 +1,25 @@
+"""openvibe skill system.
+
+Skills are prompt templates routed through the LLM, unlike slash commands
+which execute locally.  The user types ``/skillname [args]`` and the session
+expands it into a structured prompt before sending it to the model.
+
+Public API::
+
+    from openvibe.skill import SkillDefinition, SkillRegistry, get_registry, register_skill
+    from openvibe.skill.bundled import init_bundled_skills
+"""
+
+from openvibe.skill.base import (
+    SkillDefinition,
+    SkillRegistry,
+    get_registry,
+    register_skill,
+)
+
+__all__ = [
+    "SkillDefinition",
+    "SkillRegistry",
+    "get_registry",
+    "register_skill",
+]

--- a/openvibe/skill/base.py
+++ b/openvibe/skill/base.py
@@ -1,0 +1,126 @@
+"""Skill base class and registry.
+
+Skills are prompt templates that route through the LLM — unlike slash
+commands, which execute locally and never touch the model.
+
+When the user types ``/simplify`` the session detects it as a skill,
+expands the skill's prompt via ``get_prompt()``, and passes that text to
+the LLM as the user message.  From the LLM's perspective it is a normal
+user message, so all tools and permissions remain in effect.
+
+Implementing a custom skill
+---------------------------
+Subclass ``SkillDefinition`` and implement ``get_prompt()``::
+
+    from openvibe.skill.base import SkillDefinition, get_registry
+
+    class MySkill(SkillDefinition):
+        name = "myskill"
+        description = "Does something useful."
+        aliases = ["ms"]
+
+        def get_prompt(self, args: str) -> str:
+            return f"Please do something useful with: {args}" if args else (
+                "Please do something useful with the current codebase."
+            )
+
+    get_registry().register(MySkill())
+
+Then call ``get_registry().register(MySkill())`` at import time or in your
+startup hook.
+"""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass, field
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# SkillDefinition
+# ---------------------------------------------------------------------------
+
+
+class SkillDefinition(abc.ABC):
+    """Abstract base for all openvibe skills.
+
+    Subclasses must set ``name`` and ``description`` as class attributes and
+    implement ``get_prompt()``.
+    """
+
+    name: str  # must be set by subclass
+    description: str  # must be set by subclass
+    aliases: list[str] = []  # optional shorthand names
+    user_invocable: bool = True  # show in /skills list
+    when_to_use: str = ""  # hint shown in /skills
+    argument_hint: str = ""  # e.g. "[focus area]" — shown after name in /help
+
+    @abc.abstractmethod
+    def get_prompt(self, args: str) -> str:
+        """Return the expanded prompt to send to the LLM.
+
+        *args* is everything the user typed after the skill name (may be empty).
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class SkillRegistry:
+    """Holds all registered skills, keyed by name and aliases."""
+
+    def __init__(self) -> None:
+        # Primary lookup: name → skill
+        self._skills: dict[str, SkillDefinition] = {}
+        # Alias lookup: alias → primary name
+        self._aliases: dict[str, str] = {}
+
+    def register(self, skill: SkillDefinition) -> None:
+        """Register *skill* by its name and any aliases."""
+        self._skills[skill.name] = skill
+        for alias in skill.aliases:
+            self._aliases[alias] = skill.name
+
+    def get(self, name: str) -> SkillDefinition | None:
+        """Look up a skill by name or alias; returns None if not found."""
+        if name in self._skills:
+            return self._skills[name]
+        primary = self._aliases.get(name)
+        if primary:
+            return self._skills.get(primary)
+        return None
+
+    def all(self) -> list[SkillDefinition]:
+        """Return all registered skills (no duplicates from aliases)."""
+        return list(self._skills.values())
+
+    def user_invocable(self) -> list[SkillDefinition]:
+        """Return all skills that should appear in /skills."""
+        return [s for s in self._skills.values() if s.user_invocable]
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._skills or name in self._aliases
+
+
+# ---------------------------------------------------------------------------
+# Global singleton
+# ---------------------------------------------------------------------------
+
+_registry: SkillRegistry | None = None
+
+
+def get_registry() -> SkillRegistry:
+    """Return the process-wide skill registry (created on first call)."""
+    global _registry
+    if _registry is None:
+        _registry = SkillRegistry()
+    return _registry
+
+
+def register_skill(skill: SkillDefinition) -> None:
+    """Convenience wrapper: register *skill* in the global registry."""
+    get_registry().register(skill)

--- a/openvibe/skill/bundled/__init__.py
+++ b/openvibe/skill/bundled/__init__.py
@@ -1,0 +1,34 @@
+"""Bundled (built-in) skills for openvibe.
+
+Call ``init_bundled_skills()`` once at startup to register all bundled skills
+in the global registry.  This is called automatically by ``OpenVibe.start()``
+and ``OpenVibe.start_async()``.
+"""
+
+from __future__ import annotations
+
+from openvibe.skill.base import get_registry
+from openvibe.skill.bundled.commit import CommitSkill
+from openvibe.skill.bundled.debug import DebugSkill
+from openvibe.skill.bundled.plan import PlanSkill
+from openvibe.skill.bundled.simplify import SimplifySkill
+
+__all__ = ["init_bundled_skills"]
+
+_BUNDLED: list[type] = [
+    SimplifySkill,
+    DebugSkill,
+    PlanSkill,
+    CommitSkill,
+]
+
+
+def init_bundled_skills() -> None:
+    """Register all bundled skills in the global registry.
+
+    Safe to call multiple times — skills are registered by name so duplicate
+    calls simply overwrite with the same instance.
+    """
+    registry = get_registry()
+    for cls in _BUNDLED:
+        registry.register(cls())

--- a/openvibe/skill/bundled/commit.py
+++ b/openvibe/skill/bundled/commit.py
@@ -1,0 +1,46 @@
+"""Built-in /commit skill (alias /gc).
+
+Generates a well-structured git commit for staged or recent changes.
+"""
+
+from __future__ import annotations
+
+from openvibe.skill.base import SkillDefinition
+
+
+class CommitSkill(SkillDefinition):
+    name = "commit"
+    description = "Generate and create a git commit for the current changes."
+    aliases: list[str] = ["gc"]
+    user_invocable = True
+    when_to_use = "When you want to commit work-in-progress or completed changes."
+    argument_hint = "[commit message hint]"
+
+    def get_prompt(self, args: str) -> str:
+        hint = f"\n\nHint from user: {args.strip()}" if args.strip() else ""
+        return f"""\
+Create a git commit for the current changes.{hint}
+
+Steps:
+
+1. Run `git status` to see which files are modified, staged, and untracked.
+
+2. Run `git diff` (and `git diff --cached` if anything is staged) to review
+   the actual changes.
+
+3. Run `git log --oneline -10` to understand this repository's commit message
+   style and tense.
+
+4. Draft a commit message:
+   - First line: ≤72 characters, imperative mood ("Add X", "Fix Y", "Remove Z").
+   - If the change needs more explanation, add a blank line then a short
+     paragraph (or bullet list) describing *why*, not just *what*.
+   - Do NOT mention file names in the subject unless they are the entire point.
+
+5. Stage all relevant files (`git add <files>`) — be explicit; avoid `git add -A`
+   unless you have confirmed there are no secrets or generated files.
+
+6. Commit with the drafted message.
+
+7. Confirm with `git log -1 --stat` and show the result.
+"""

--- a/openvibe/skill/bundled/debug.py
+++ b/openvibe/skill/bundled/debug.py
@@ -1,0 +1,46 @@
+"""Built-in /debug skill.
+
+Systematically diagnoses and fixes a bug or error in the codebase.
+"""
+
+from __future__ import annotations
+
+from openvibe.skill.base import SkillDefinition
+
+
+class DebugSkill(SkillDefinition):
+    name = "debug"
+    description = "Systematically diagnose and fix a bug or error."
+    aliases: list[str] = []
+    user_invocable = True
+    when_to_use = "When you have an error, failing test, or unexpected behaviour to investigate."
+    argument_hint = "[error message or description]"
+
+    def get_prompt(self, args: str) -> str:
+        problem = f"Problem to debug: {args.strip()}" if args.strip() else (
+            "Identify the most recent error or failing behaviour in this session."
+        )
+        return f"""\
+{problem}
+
+Debug this systematically:
+
+1. **Reproduce** — confirm the error is real and understand the exact conditions
+   that trigger it. Run the failing test or command if possible.
+
+2. **Locate** — read the relevant source files and stack traces. Identify the
+   exact line(s) and the immediate cause (wrong value, missing check, off-by-one,
+   incorrect assumption, etc.).
+
+3. **Understand root cause** — trace back one level further. Why does the
+   immediate cause exist? (Missing guard? Wrong data flow? API misuse?)
+
+4. **Fix** — apply the minimal correct change. Do not refactor surrounding code
+   unless it is directly causing the bug.
+
+5. **Verify** — re-run the failing test or reproduce step to confirm the fix
+   works. Check that no related tests broke.
+
+6. **Summarise** — one short paragraph: what the bug was, why it happened, and
+   what was changed.
+"""

--- a/openvibe/skill/bundled/debug.py
+++ b/openvibe/skill/bundled/debug.py
@@ -13,12 +13,18 @@ class DebugSkill(SkillDefinition):
     description = "Systematically diagnose and fix a bug or error."
     aliases: list[str] = []
     user_invocable = True
-    when_to_use = "When you have an error, failing test, or unexpected behaviour to investigate."
+    when_to_use = (
+        "When you have an error, failing test, or unexpected behaviour to investigate."
+    )
     argument_hint = "[error message or description]"
 
     def get_prompt(self, args: str) -> str:
-        problem = f"Problem to debug: {args.strip()}" if args.strip() else (
-            "Identify the most recent error or failing behaviour in this session."
+        problem = (
+            f"Problem to debug: {args.strip()}"
+            if args.strip()
+            else (
+                "Identify the most recent error or failing behaviour in this session."
+            )
         )
         return f"""\
 {problem}

--- a/openvibe/skill/bundled/plan.py
+++ b/openvibe/skill/bundled/plan.py
@@ -1,0 +1,44 @@
+"""Built-in /plan skill.
+
+Produces a concrete implementation plan for a feature, refactor, or task.
+"""
+
+from __future__ import annotations
+
+from openvibe.skill.base import SkillDefinition
+
+
+class PlanSkill(SkillDefinition):
+    name = "plan"
+    description = "Produce a concrete, step-by-step implementation plan."
+    aliases: list[str] = []
+    user_invocable = True
+    when_to_use = "Before starting a non-trivial task to align on approach and surface risks early."
+    argument_hint = "<task description>"
+
+    def get_prompt(self, args: str) -> str:
+        task = args.strip() or "the task described in this session"
+        return f"""\
+Create a concrete implementation plan for: {task}
+
+Steps:
+
+1. **Understand the scope** — read the relevant source files, tests, and
+   configuration. Use glob/grep to explore if you are unsure where things live.
+
+2. **Identify constraints** — existing patterns, frameworks in use, permission
+   boundaries, performance requirements, and anything that limits options.
+
+3. **Draft the plan** — produce a numbered list of discrete, ordered steps.
+   Each step must be:
+   - Actionable (a specific file change, command, or decision)
+   - Atomic (one logical change per step)
+   - Justified (a brief reason why)
+
+4. **Call out risks** — list 2-4 things that could go wrong and how to mitigate
+   them (e.g. breaking changes, race conditions, missing tests).
+
+5. **Estimate complexity** — S / M / L and a one-sentence explanation.
+
+Do NOT start implementing yet. Return only the plan.
+"""

--- a/openvibe/skill/bundled/simplify.py
+++ b/openvibe/skill/bundled/simplify.py
@@ -1,0 +1,46 @@
+"""Built-in /simplify skill.
+
+Reviews recently changed code for reuse opportunities, quality issues,
+and efficiency improvements, then fixes what it finds.
+"""
+
+from __future__ import annotations
+
+from openvibe.skill.base import SkillDefinition
+
+
+class SimplifySkill(SkillDefinition):
+    name = "simplify"
+    description = "Review changed code for reuse, quality, and efficiency, then fix any issues found."
+    aliases: list[str] = []
+    user_invocable = True
+    when_to_use = "After writing or editing code to catch and fix common issues."
+    argument_hint = "[focus area]"
+
+    def get_prompt(self, args: str) -> str:
+        focus = f"\n\nFocus area: {args}" if args.strip() else ""
+        return f"""\
+Review the code changes in this session for quality issues, then fix what you find.{focus}
+
+Follow these steps:
+
+1. Run `git diff HEAD` (or inspect recently written/edited files) to identify all changes.
+
+2. Launch three parallel review passes:
+   - **Reuse review**: Look for duplicated logic that could be extracted into a helper,
+     repeated patterns that belong in a shared utility, or code that already exists
+     elsewhere in the repo.
+   - **Quality review**: Check naming clarity, error handling, edge cases, type hints,
+     missing tests, and anything that would confuse a reviewer.
+   - **Efficiency review**: Identify unnecessary loops, redundant I/O, avoidable
+     re-computation, or data structures better suited to the access pattern.
+
+3. Aggregate findings. For each issue, decide:
+   - Is it a real problem worth fixing right now? (Skip cosmetic nits.)
+   - What is the minimal change that resolves it without over-engineering?
+
+4. Apply fixes directly. Do not ask for confirmation unless a change is destructive
+   or would affect files outside the current diff.
+
+5. When done, summarise what was changed and why in one short paragraph.
+"""

--- a/openvibe/tui/screens/session.py
+++ b/openvibe/tui/screens/session.py
@@ -36,7 +36,7 @@ class SessionScreen(Screen):
     BINDINGS = [
         Binding("ctrl+s", "sessions", "Sessions", show=True),
         Binding("ctrl+n", "new_session", "New", show=True),
-        Binding("escape", "noop", ""),
+        Binding("escape", "cancel_turn", "Cancel", show=False),
     ]
 
     def __init__(self, session_id: str, **kwargs: Any) -> None:
@@ -263,7 +263,10 @@ class SessionScreen(Screen):
 
         # Persist and display the command as a user message.
         user_msg = session_store.add_message(
-            db, self._session_id, MessageRole.USER, [TextPart(content=text)],
+            db,
+            self._session_id,
+            MessageRole.USER,
+            [TextPart(content=text)],
         )
         widget = await msg_list.add_message(user_msg.id, "user")
         widget.append_text(text)
@@ -288,16 +291,19 @@ class SessionScreen(Screen):
             return
 
         # Persist and display the result as a system message.
-        # Command output is Rich markup, not markdown — use SYSTEM role so that
-        # it bypasses the markdown renderer (render_markdown / mistune) and is
-        # passed directly to Static.update() which interprets Rich markup tags.
+        # Command output is Rich markup, not markdown — use SYSTEM role so it
+        # bypasses the markdown/mistune pipeline and goes directly to
+        # Static.update(), which interprets Rich markup tags correctly.
         if result.output:
             reply_msg = session_store.add_message(
-                db, self._session_id, MessageRole.SYSTEM,
+                db,
+                self._session_id,
+                MessageRole.SYSTEM,
                 [TextPart(content=result.output)],
             )
             result_widget = await msg_list.add_message(
-                reply_msg.id, str(MessageRole.SYSTEM),
+                reply_msg.id,
+                str(MessageRole.SYSTEM),
             )
             result_widget.replace_text(result.output)
 
@@ -609,5 +615,11 @@ class SessionScreen(Screen):
             event.prevent_default()
             input_bar.post_message(InputBar.Submitted("3"))
 
-    def action_noop(self) -> None:
-        pass
+    def action_cancel_turn(self) -> None:
+        """Cancel the active agent turn (escape)."""
+        session = self.app.get_session(self._session_id)  # type: ignore[attr-defined]
+        if session.state != SessionState.THINKING:
+            return
+        session.abort()
+        self.query_one(InputBar).enable()
+        self._refresh_header()

--- a/openvibe/tui/screens/session.py
+++ b/openvibe/tui/screens/session.py
@@ -291,9 +291,6 @@ class SessionScreen(Screen):
             return
 
         # Persist and display the result as a system message.
-        # Command output is Rich markup, not markdown — use SYSTEM role so it
-        # bypasses the markdown/mistune pipeline and goes directly to
-        # Static.update(), which interprets Rich markup tags correctly.
         if result.output:
             reply_msg = session_store.add_message(
                 db,

--- a/openvibe/tui/screens/session.py
+++ b/openvibe/tui/screens/session.py
@@ -170,7 +170,8 @@ class SessionScreen(Screen):
 
             for i, part in enumerate(msg.parts):
                 if isinstance(part, TextPart):
-                    if role == "permission":
+                    if role in ("permission", "system"):
+                        # Rich markup — bypass the markdown pipeline.
                         widget.replace_text(part.content)
                     else:
                         widget.append_text(part.content)
@@ -221,11 +222,17 @@ class SessionScreen(Screen):
 
         # Slash commands — handled at the API level, but we intercept the
         # result here to avoid freezing the UI / showing a spinner.
-        from openvibe.commands import is_command
+        # Skills look like commands (/simplify, /plan, …) but are NOT in the
+        # command registry — they must go through the LLM path (_start_turn).
+        from openvibe.commands import get_command, has_command, is_command
 
         if is_command(event.text):
-            await self._handle_command(event.text)
-            return
+            parsed = get_command(event.text)
+            if parsed and has_command(parsed[0]):
+                await self._handle_command(event.text)
+                return
+            # Not a registered command — fall through to LLM path so that
+            # Session._try_skill() can expand it.
 
         input_bar = self.query_one(InputBar)
         input_bar.record_submission(event.text)
@@ -280,16 +287,19 @@ class SessionScreen(Screen):
             msg_list._messages.clear()
             return
 
-        # Persist and display the result as an assistant message.
+        # Persist and display the result as a system message.
+        # Command output is Rich markup, not markdown — use SYSTEM role so that
+        # it bypasses the markdown renderer (render_markdown / mistune) and is
+        # passed directly to Static.update() which interprets Rich markup tags.
         if result.output:
             reply_msg = session_store.add_message(
-                db, self._session_id, MessageRole.ASSISTANT,
+                db, self._session_id, MessageRole.SYSTEM,
                 [TextPart(content=result.output)],
             )
             result_widget = await msg_list.add_message(
-                reply_msg.id, str(MessageRole.ASSISTANT),
+                reply_msg.id, str(MessageRole.SYSTEM),
             )
-            result_widget.append_text(result.output)
+            result_widget.replace_text(result.output)
 
     # ------------------------------------------------------------------
     # Permission handling


### PR DESCRIPTION
  New: openvibe/skill/ package                                                  
  - skill/base.py — SkillDefinition ABC, SkillRegistry with name + alias lookup,
   get_registry() singleton, register_skill() helper                            
  - skill/__init__.py — public exports                                       
  - skill/bundled/__init__.py — init_bundled_skills() called at startup to      
  register all built-in skills                                               
  - skill/bundled/simplify.py — /simplify [focus] — parallel code review (reuse,
   quality, efficiency) then fixes issues                                       
  - skill/bundled/debug.py — /debug [error] — reproduce → locate → fix → verify 
  loop                                                                         
  - skill/bundled/plan.py — /plan <task> — structured implementation plan, no   
  code written                                                               
  - skill/bundled/commit.py — /commit (alias /gc) — stages changes and creates a
   well-formed git commit                                                       
                                                                                
  Modified: openvibe/api.py                                                  
  - Added Session._try_skill() — detects /skillname input, looks up skill by    
  name or alias, returns expanded prompt                                        
  - Session._try_command() now returns None for unregistered names instead of an
   "Unknown command" error, allowing skills to be reached                       
  - send() and send_nowait() check for skill expansion between command detection
   and LLM dispatch                                                             
  - OpenVibe.start() and start_async() call init_bundled_skills() at startup    
                                                                             
  Modified: openvibe/commands.py                                                
  - Added has_command(name) — checks if a name is a registered slash command    
  - Added /skills command — lists all user-invocable skills with descriptions,  
  aliases, and when-to-use hints                                                
  - Updated /help to include a skills section at the bottom                     
                                                           
  Modified: openvibe/tui/screens/session.py                                     
  - handle_submitted now checks has_command() before routing to _handle_command;
   unregistered /foo falls through to the LLM path so skills stream correctly   
  - _handle_command stores command output as MessageRole.SYSTEM (was ASSISTANT) 
  and calls replace_text to bypass the markdown/mistune pipeline — fixes a crash
   where Rich markup tags like [commit message hint] were misinterpreted as     
  color names                                                              
  - _load_history renders system role messages with replace_text on reload,     
  consistent with live rendering                                             
                                   