### PR TITLE
upd: tests workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10"]
+        python-version: ["3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3
@@ -23,7 +23,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install --upgrade pip pytest
-        pip install .
+        pip install --upgrade pip
+        pip install ".[dev]"
     - name: Test with Pytest
       run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,4 +62,5 @@ plugins = ["pydantic.mypy"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+pythonpath = ["."]
 markers = ["integration: live network tests (require internet access)"]

--- a/tests/test_tool_decorator.py
+++ b/tests/test_tool_decorator.py
@@ -25,7 +25,7 @@ def _ctx() -> ToolContext:
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
  1. .github/workflows/test.yml — bumped the matrix to Python 3.11/3.12, and
  changed the install step to pip install ".[dev]" (the plain pip install . was
  also missing pytest-asyncio, which the test suite requires via asyncio_mode = 
  "auto").
  2. tests/test_tool_decorator.py — its _run() helper used the deprecated
  asyncio.get_event_loop(), which raises RuntimeError on Python 3.12 with no
  existing loop. Fixed to asyncio.run(coro).